### PR TITLE
track resholveScript -> resholve.writeScript rename

### DIFF
--- a/home-in-details/program/qute/default.nix
+++ b/home-in-details/program/qute/default.nix
@@ -2,7 +2,7 @@
 let
   inherit (pkgs)
     qutebrowser substituteAll symlinkJoin makeWrapper keyutils writeShellScript
-    resholveScript xclip jq bitwarden-cli rofi bash coreutils gnused;
+    resholve xclip jq bitwarden-cli rofi bash coreutils gnused;
   inherit (constant) proxy;
   inherit (lib) fold optionalAttrs mkMerge mkIf;
   inherit (builtins) readFile;
@@ -11,7 +11,7 @@ let
 
   mergeFiles = files: fold (s1: s2: s1 + s2) "" (map readFile files);
   outPath = placeholder "out";
-  vaultwardenScript = resholveScript "vaultwarden-fill" {
+  vaultwardenScript = resholve.writeScript "vaultwarden-fill" {
     inputs = [ keyutils rofi xclip jq bitwarden-cli coreutils gnused ];
     interpreter = "${bash}/bin/bash";
     execer = [


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/167905, which reorganized resholve's Nix API a bit, landed in unstable this week. Since you have public uses, I prepared a quick PR to migrate them in case it's helpful.